### PR TITLE
Make version check compatible with new major versions

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -24,7 +24,7 @@ end
 
 let ocaml_version = V1.ocaml_version |> parse
 
-let has_bigarray_in_stdlib = major ocaml_version >= 4 && minor ocaml_version >= 7
+let has_bigarray_in_stdlib = (major ocaml_version, minor ocaml_version) >= (4, 7)
 let base_dune = "(library (name bigarray_compat) (public_name bigarray-compat) (modules bigarray_compat) (wrapped false)"
 
 let dune_file_stdlib = base_dune^") (rule (targets bigarray_compat.ml) (action (copy bigarray_stdlib.ml bigarray_compat.ml)))"


### PR DESCRIPTION
Hi!

The previous version would check if both are greater, so `5.0` would be considered lower. It can be fixed by using lexicographic comparison.

(if this piece of code was copied from another project in might be interesting to know if it needs fixing over there as well)