### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/bigarray-compat.opam
+++ b/bigarray-compat.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 synopsis:
   "Compatibility library to use Stdlib.Bigarray when possible"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.