### PR TITLE
Add a dependency to bigarray on OCaml 4.07 as the toplevel Bigarray module (library) shadows Stdlib.Bigarray in OCaml < 4.08

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -25,10 +25,14 @@ end
 let ocaml_version = V1.ocaml_version |> parse
 
 let has_bigarray_in_stdlib = (major ocaml_version, minor ocaml_version) >= (4, 7)
-let base_dune = "(library (name bigarray_compat) (public_name bigarray-compat) (modules bigarray_compat) (wrapped false)"
+let is_bigarray_lib_shadowed = (major ocaml_version, minor ocaml_version) >= (4, 8)
+let base_dune =
+  Printf.sprintf
+    "(library (name bigarray_compat) (public_name bigarray-compat) (modules bigarray_compat) (wrapped false)%s)"
+    (if is_bigarray_lib_shadowed then "" else " (libraries bigarray)")
 
-let dune_file_stdlib = base_dune^") (rule (targets bigarray_compat.ml) (action (copy bigarray_stdlib.ml bigarray_compat.ml)))"
-let dune_file_pre407 = base_dune^"(libraries bigarray)) (rule (targets bigarray_compat.ml) (action (copy bigarray_pre407.ml bigarray_compat.ml)))"
+let dune_file_stdlib = base_dune^" (rule (targets bigarray_compat.ml) (action (copy bigarray_stdlib.ml bigarray_compat.ml)))"
+let dune_file_pre407 = base_dune^" (rule (targets bigarray_compat.ml) (action (copy bigarray_pre407.ml bigarray_compat.ml)))"
 
 let _ = match has_bigarray_in_stdlib with
     | true -> V1.send dune_file_stdlib


### PR DESCRIPTION
This is a problem for libraries that depend on bigarray-compat but where packages that uses those libraries are using Bigarray themselves.

See https://github.com/ocaml/ocaml/pull/2041

Example of such failure on OCaml 4.07:
```
#=== ERROR while compiling tsdl-image.0.4 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.07.1 | pinned(https://github.com/sanette/tsdl-image/archive/0.4.tar.gz)
# path                 ~/.opam/4.07/.opam-switch/build/tsdl-image.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tsdl-image -j 71 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/tsdl-image-7-7af88e.env
# output-file          ~/.opam/log/tsdl-image-7-7af88e.out
### output ###
# (cd _build/default && /home/opam/.opam/4.07/bin/ocamlopt.opt -w -40 -g -o test/test.exe /home/opam/.opam/4.07/lib/bigarray-compat/bigarray_compat.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/4.07/lib/integers/integers.cmxa -I /home/opam/.opam/4.07/lib/integers /home/opam/.opam/4.07/lib/ctypes/ctypes.cmxa -I /home/opam/.opam/4.07/lib/ctypes /home/opam/.opam/4.07/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ctypes/ctypes-foreign.cmxa -I /home/opam/.opam/4.07/lib/ctypes /home/opam/.opam/4.07/lib/tsdl/tsdl.cmxa -I /home/opam/.opam/4.07/lib/tsdl src/tsdl_image.cmxa test/.test.eobjs/native/dune__exe__Test.cmx)
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Bigarray referenced from /home/opam/.opam/4.07/lib/tsdl/tsdl.cmxa(Tsdl)
```