### PR TITLE
Set min dune version to 1.5

### DIFF
--- a/bigarray-compat.opam
+++ b/bigarray-compat.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {>= "1.0"}
+  "dune" {>= "1.5"}
 ]
 synopsis:
   "Compatibility library to use Stdlib.Bigarray when possible"


### PR DESCRIPTION
The lint-lower-bounds test in ocaml-ci build the @check dune alias but
that was only added to dune in version 1.5, so it fails on projects
whose min dune version is less than 1.5.
